### PR TITLE
use superqt instead of napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "mypy_extensions",
     "importlib_metadata ; python_version < '3.8'",
     "pygame",
+    "psygnal",
+    "superqt>=0.2.5",
 ]
 
 # extras

--- a/src/pulser/midi.py
+++ b/src/pulser/midi.py
@@ -1,5 +1,5 @@
 import time
-from napari.qt.threading import thread_worker
+from superqt.utils import thread_worker
 from psygnal import Signal
 import pygame.midi
 import logging


### PR DESCRIPTION
the `thread_worker` decorator pattern that I added in napari was extracted to superqt: https://pyapp-kit.github.io/superqt/utilities/threading/

so until you know you need a full napari dependency, this would be a much smaller requirement.